### PR TITLE
timezoneの設定

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,7 @@ module RailsNetflixApp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    # Set the default time zone
+    config.time_zone = 'Tokyo'
   end
 end


### PR DESCRIPTION
### issue
https://github.com/Hashimoto-Noriaki/rails_netflix_app/issues/13#issue-2341992912

### 変更点
- config/application.rb

### 変更理由
DBに保存される時間を海外の時間から日本時間に変更



